### PR TITLE
Fixing typo in Standard Library

### DIFF
--- a/src/main/scala/scalatutorial/sections/StandardLibrary.scala
+++ b/src/main/scala/scalatutorial/sections/StandardLibrary.scala
@@ -64,7 +64,7 @@ object StandardLibrary extends ScalaTutorialSection {
    *   val nums = 1 :: 2 :: 3 :: 4 :: Nil
    * }}}
    *
-   * Operators ending in “`:`” are also different in the they are seen as method calls of
+   * Operators ending in “`:`” are also different in the fact that they are seen as method calls of
    * the ''right-hand'' operand.
    *
    * So the expression above is equivalent to:


### PR DESCRIPTION
Fixing typo in the Standard Library section