### PR TITLE
Changing abs() to accept Double instead of Int

### DIFF
--- a/src/main/scala/scalatutorial/sections/FunctionalLoops.scala
+++ b/src/main/scala/scalatutorial/sections/FunctionalLoops.scala
@@ -19,7 +19,7 @@ object FunctionalLoops extends ScalaTutorialSection {
    * Example:
    *
    * {{{
-   *   def abs(x: Int) = if (x >= 0) x else -x
+   *   def abs(x: Double) = if (x >= 0) x else -x
    * }}}
    *
    * `x >= 0` is a ''predicate'', of type `Boolean`.


### PR DESCRIPTION
As requested on #24.

Changing abs() to accept Double instead of Int in FunctionalLoops lesson, which solves compilation problems in isGoodEnough().

@jdesiloniz I needed another PR because I deleted my previous fork.