### PR TITLE
Renaming the aux directory to avoid issues with Windows developers

### DIFF
--- a/src/main/scala/scalatutorial/sections/ClassesVsCaseClasses.scala
+++ b/src/main/scala/scalatutorial/sections/ClassesVsCaseClasses.scala
@@ -5,7 +5,7 @@
 
 package scalatutorial.sections
 
-import scalatutorial.aux.{BankAccount, Note}
+import scalatutorial.utils.{BankAccount, Note}
 
 /** @param name classes_vs_case_classes */
 object ClassesVsCaseClasses extends ScalaTutorialSection {

--- a/src/main/scala/scalatutorial/sections/ImperativeProgramming.scala
+++ b/src/main/scala/scalatutorial/sections/ImperativeProgramming.scala
@@ -5,7 +5,7 @@
 
 package scalatutorial.sections
 
-import scalatutorial.aux.BankAccount
+import scalatutorial.utils.BankAccount
 
 /** @param name imperative_programming */
 object ImperativeProgramming extends ScalaTutorialSection {

--- a/src/main/scala/scalatutorial/sections/ObjectOrientedProgramming.scala
+++ b/src/main/scala/scalatutorial/sections/ObjectOrientedProgramming.scala
@@ -5,7 +5,7 @@
 
 package scalatutorial.sections
 
-import scalatutorial.aux.{Empty, IntSet, NonEmpty}
+import scalatutorial.utils.{Empty, IntSet, NonEmpty}
 
 /** @param name object_oriented_programming */
 object ObjectOrientedProgramming extends ScalaTutorialSection {

--- a/src/main/scala/scalatutorial/sections/TypeClasses.scala
+++ b/src/main/scala/scalatutorial/sections/TypeClasses.scala
@@ -5,8 +5,8 @@
 
 package scalatutorial.sections
 
-import scalatutorial.aux.Rational
-import scalatutorial.aux.Sorting.insertionSort
+import scalatutorial.utils.Rational
+import scalatutorial.utils.Sorting.insertionSort
 
 /** @param name type_classes */
 object TypeClasses extends ScalaTutorialSection {

--- a/src/main/scala/scalatutorial/utils/BankAccount.scala
+++ b/src/main/scala/scalatutorial/utils/BankAccount.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 
-package scalatutorial.aux
+package scalatutorial.utils
 
 class BankAccount {
 

--- a/src/main/scala/scalatutorial/utils/IntSet.scala
+++ b/src/main/scala/scalatutorial/utils/IntSet.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 
-package scalatutorial.aux
+package scalatutorial.utils
 
 abstract class IntSet {
   def incl(x: Int): IntSet

--- a/src/main/scala/scalatutorial/utils/Note.scala
+++ b/src/main/scala/scalatutorial/utils/Note.scala
@@ -3,6 +3,6 @@
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 
-package scalatutorial.aux
+package scalatutorial.utils
 
 case class Note(name: String, duration: String, octave: Int)

--- a/src/main/scala/scalatutorial/utils/Rational.scala
+++ b/src/main/scala/scalatutorial/utils/Rational.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 
-package scalatutorial.aux
+package scalatutorial.utils
 
 class Rational(x: Int, y: Int) {
 

--- a/src/main/scala/scalatutorial/utils/animals.scala
+++ b/src/main/scala/scalatutorial/utils/animals.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 
-package scalatutorial.aux
+package scalatutorial.utils
 
 trait Animal {
   def fitness: Int

--- a/src/main/scala/scalatutorial/utils/sorting.scala
+++ b/src/main/scala/scalatutorial/utils/sorting.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 
-package scalatutorial.aux
+package scalatutorial.utils
 
 object Sorting {
 

--- a/src/test/scala/scalatutorial/sections/TypeClassesSpec.scala
+++ b/src/test/scala/scalatutorial/sections/TypeClassesSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.Spec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-import scalatutorial.aux.Rational
+import scalatutorial.utils.Rational
 
 class TypeClassesSpec extends Spec with Checkers {
 


### PR DESCRIPTION
This PR reorganizes a little bit the structure of this content library to avoid issues with Windows developers, as it seems that from Windows 7 the `aux` folder name is reserved and can't be used in the filesystem.

Suggested by @Tschis. Thanks!