### PR TITLE
Fix insertionSort function in TypeClasses.scala

### DIFF
--- a/src/main/scala/scalatutorial/sections/TypeClasses.scala
+++ b/src/main/scala/scalatutorial/sections/TypeClasses.scala
@@ -51,7 +51,7 @@ object TypeClasses extends ScalaTutorialSection {
    * parameter:
    *
    * {{{
-   *   def insertionSort[T](xs: List[T])(lessThan: (T, T) => Boolean) = {
+   *   def insertionSort[T](xs: List[T])(lessThan: (T, T) => Boolean): List[T] = {
    *     def insert(y: T, ys: List[T]): List[T] =
    *       ys match {
    *         …


### PR DESCRIPTION
You have to add result type in order to call insertionSort as stated in "Calling Parameterized Sort".