### PR TITLE
Fix `error: value to is not a member of Boolean`

### DIFF
--- a/src/main/scala/scalatutorial/sections/TermsAndTypes.scala
+++ b/src/main/scala/scalatutorial/sections/TermsAndTypes.scala
@@ -143,7 +143,7 @@ object TermsAndTypes extends ScalaTutorialSection {
    * The infix syntax can also be used with regular methods:
    *
    * {{{
-   *   1.to(10) == 1 to 10
+   *   1.to(10) == (1 to 10)
    * }}}
    *
    * Any method with a parameter can be used like an infix operator.


### PR DESCRIPTION
Change `1.to(10) == 1 to 10` to `1.to(10) == (1 to 10)` because execution of the original code throws the following error:

```
<console>:24: error: value to is not a member of Boolean
       1.to(10) == 1 to 10
```