### PR TITLE
Clarify documentation of square root example

### DIFF
--- a/src/main/scala/scalatutorial/sections/FunctionalLoops.scala
+++ b/src/main/scala/scalatutorial/sections/FunctionalLoops.scala
@@ -76,7 +76,7 @@ object FunctionalLoops extends ScalaTutorialSection {
    *  - Start with an initial ''estimate'' `y` (let's pick `y = 1`).
    *  - Repeatedly improve the estimate by taking the mean of `y` and `x/y`.
    *
-   * Example:
+   * Example: Evaluation of the square root of 2 (x = 2):
    *
    * {{{
    *   Estimation          Quotient              Mean


### PR DESCRIPTION
Explicitly call out that that we're evaluating the square root of 2 in example
of applying Newton's method.

---

It took me a bit to understand the variables at play in this example and though that more explicit documentation could help clarify here.