### PR TITLE
Update DefinitionsAndEvaluation.scala

### DIFF
--- a/src/main/scala/scalatutorial/sections/DefinitionsAndEvaluation.scala
+++ b/src/main/scala/scalatutorial/sections/DefinitionsAndEvaluation.scala
@@ -188,6 +188,7 @@ object DefinitionsAndEvaluation extends ScalaTutorialSection {
    *   9 + (2+2) * (2+2)
    *   9 + 4 * (2+2)
    *   9 + 4 * 4
+   *   9 + 16
    *   25
    * }}}
    *


### PR DESCRIPTION
Added  "9 + 16" on line 191, in which the exercise appeared to skip a step