### PR TITLE
Update FunctionalLoops.scala

### DIFF
--- a/src/main/scala/scalatutorial/sections/FunctionalLoops.scala
+++ b/src/main/scala/scalatutorial/sections/FunctionalLoops.scala
@@ -76,7 +76,7 @@ object FunctionalLoops extends ScalaTutorialSection {
    *  - Start with an initial ''estimate'' `y` (let's pick `y = 1`).
    *  - Repeatedly improve the estimate by taking the mean of `y` and `x/y`.
    *
-   * Example:
+   * Example: compute sqrt(2)
    *
    * {{{
    *   Estimation          Quotient              Mean


### PR DESCRIPTION
Updated line 79:
   * Example: compute sqrt(2)

to clearly indicate that the example is specific to the case of sqrt(2)