### PR TITLE
Remove misleading example

### DIFF
--- a/src/main/scala/scalatutorial/sections/StandardLibrary.scala
+++ b/src/main/scala/scalatutorial/sections/StandardLibrary.scala
@@ -96,9 +96,7 @@ object StandardLibrary extends ScalaTutorialSection {
    *     // Same as `x :: Nil`
    *     case List(x) => …
    *     // The empty list, same as `Nil`
-   *     case List() =>
-   *     // A list that contains as only element another list that starts with `2`
-   *     case List(2 :: xs) => …
+   *     case List() => …
    *   }
    * }}}
    *


### PR DESCRIPTION
While the example is interesting in that it shows an example of advanced pattern matching, it is problematic in that the pattern used is not of a valid type for the rest of the code.

As it is not really relevant to the issue at hand, and given that it's a relatively advanced example not likely to be relevant to someone first learning the language, I suggest simply removing it. A separate section on advanced pattern matching could potentially cover it.

Fixes #34