### PR TITLE
Make the equality executable in the scala shell

### DIFF
--- a/src/main/scala/scalatutorial/sections/TermsAndTypes.scala
+++ b/src/main/scala/scalatutorial/sections/TermsAndTypes.scala
@@ -143,7 +143,7 @@ object TermsAndTypes extends ScalaTutorialSection {
    * The infix syntax can also be used with regular methods:
    *
    * {{{
-   *   1.to(10) == 1 to 10
+   *   1.to(10) == (1 to 10)
    * }}}
    *
    * Any method with a parameter can be used like an infix operator.


### PR DESCRIPTION
When I run the following I get an error.
```
scala> 1.to(10) == 1 to 10
<console>:12: error: value to is not a member of Boolean
       1.to(10) == 1 to 10
```
The expected result should be
```
scala> 1.to(10) == (1 to 10)
res5: Boolean = true
```
in my opinion.