### PR TITLE
Suggested more guidance in last section of Terms and Types

### DIFF
--- a/src/main/scala/scalatutorial/sections/TermsAndTypes.scala
+++ b/src/main/scala/scalatutorial/sections/TermsAndTypes.scala
@@ -181,6 +181,7 @@ object TermsAndTypes extends ScalaTutorialSection {
    * = Exercise =
    *
    * Here are some more methods of standard types. Can you guess what they do?
+   * If you get stuck, try evaluating each statement in turn in a scala REPL to see what the result is.
    */
   def moreMethods(res0: String, res1: Boolean, res2: String): Unit = {
     16.toHexString shouldBe res0


### PR DESCRIPTION
### Changes
- Adds a little extra guidance to last section
- I found myself trying to workout why `16.toHexString` wasn't "10", only to discover when I evaluated all the statements that that answer was fine, it was the second one which was `false` rather than `true` as `until` isn't inclusive.