### PR TITLE
Rectified `to is not a member of Boolean` error

### DIFF
--- a/src/main/scala/scalatutorial/sections/TermsAndTypes.scala
+++ b/src/main/scala/scalatutorial/sections/TermsAndTypes.scala
@@ -143,7 +143,7 @@ object TermsAndTypes extends ScalaTutorialSection {
    * The infix syntax can also be used with regular methods:
    *
    * {{{
-   *   1.to(10) == 1 to 10
+   *   1.to(10) == (1 to 10)
    * }}}
    *
    * Any method with a parameter can be used like an infix operator.


### PR DESCRIPTION
Due to the order of evaluation, 
1.to(10) == 1 gets evaluated to False
and the expression becomes
False to 10

Instead evaluation should be
1.to(10) == (1 to 10)