### PR TITLE
Fix for the tail-recursive version of sum

### DIFF
--- a/src/main/scala/scalatutorial/sections/HigherOrderFunctions.scala
+++ b/src/main/scala/scalatutorial/sections/HigherOrderFunctions.scala
@@ -153,7 +153,7 @@ object HigherOrderFunctions extends ScalaTutorialSection {
   def tailRecSum(res0: Int, res1: Int): Unit = {
     def sum(f: Int => Int, a: Int, b: Int): Int = {
       def loop(x: Int, acc: Int): Int = {
-        if (x > b) acc
+        if (x == b) acc
         else loop(x + res0, acc + f(x))
       }
       loop(a, res1)


### PR DESCRIPTION
I believe there is a mistake in the last exercise, to re-write the `sum` function as a tail-recursive function. The `if` statement should say if `x == b` otherwise it goes one iteration too far.