### PR TITLE
Remove spaces around higher-precedence operators

### DIFF
--- a/src/main/scala/scalatutorial/sections/FunctionalLoops.scala
+++ b/src/main/scala/scalatutorial/sections/FunctionalLoops.scala
@@ -106,10 +106,10 @@ object FunctionalLoops extends ScalaTutorialSection {
    *
    * {{{
    *   def improve(guess: Double, x: Double) =
-   *     (guess + x / guess) / 2
+   *     (guess + x/guess) / 2
    *
    *   def isGoodEnough(guess: Double, x: Double) =
-   *     abs(guess * guess - x) < 0.001
+   *     abs(guess*guess - x) < 0.001
    * }}}
    *
    * Third, we define the `sqrt` function:


### PR DESCRIPTION
Not sure if this is the convention in Scala as it is in some other languages, but removing the spaces around the higher-precedence operators makes these expressions much more readable, IMO.  Just a suggestion -- applies throughout the tutorial but will only propose here as I know it's a matter of style.  (If agreed I am happy to make the changes elsewhere.)