### PR TITLE
edit typo for redefined

### DIFF
--- a/src/main/scala/scalatutorial/sections/LexicalScopes.scala
+++ b/src/main/scala/scalatutorial/sections/LexicalScopes.scala
@@ -80,7 +80,7 @@ object LexicalScopes extends ScalaTutorialSection {
    * = Lexical Scoping =
    *
    * Definitions of outer blocks are visible inside a block unless they are shadowed.
-   * Shadowed defintions are ones which are redfined in a lower scope.
+   * Shadowed defintions are ones which are redefined in a lower scope.
    *
    * Therefore, we can simplify `sqrt` by eliminating redundant occurrences of the `x` parameter, which means
    * the same thing everywhere:


### PR DESCRIPTION
There's a typo in word redefined in Lexical Scope definition section 