### PR TITLE
Updated ScalaTest 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ lazy val `scala-tutorial` = (project in file("."))
       %%("shapeless", V.shapeless),
       %%("scalatest", V.scalatest),
       %%("scalacheck", V.scalacheck),
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless,
+      "org.scalatestplus"          %% "scalatestplus-scalacheck"    % V.scalatestplusScheck
     )
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -17,7 +17,8 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val scala212: String            = "2.12.10"
       val shapeless: String           = "2.3.3"
-      val scalatest: String           = "3.0.8"
+      val scalatest: String           = "3.1.0"
+      val scalatestplusScheck: String = "3.1.0.0-RC2"
       val scalacheck: String          = "1.14.2"
       val scalacheckShapeless: String = "1.2.3"
     }

--- a/src/main/scala/scalatutorial/sections/ScalaTutorialSection.scala
+++ b/src/main/scala/scalatutorial/sections/ScalaTutorialSection.scala
@@ -7,6 +7,7 @@
 package scalatutorial.sections
 
 import org.scalaexercises.definitions.Section
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-trait ScalaTutorialSection extends FlatSpec with Matchers with Section
+trait ScalaTutorialSection extends AnyFlatSpec with Matchers with Section


### PR DESCRIPTION
This PR updates ScalaTest dependency to version 3.1.0.