### PR TITLE
Suggest using `toList` instead of `to(List)`

### DIFF
--- a/src/main/scala/scalatutorial/sections/SyntacticConveniences.scala
+++ b/src/main/scala/scalatutorial/sections/SyntacticConveniences.scala
@@ -342,7 +342,7 @@ object SyntacticConveniences extends ScalaTutorialSection {
    */
   def repeatedParameters(res0: Double): Unit = {
     def average(x: Int, xs: Int*): Double =
-      (x :: xs.to(List)).sum.toDouble / (xs.size + 1)
+      (x :: xs.toList).sum.toDouble / (xs.size + 1)
 
     average(1) shouldBe 1.0
     average(1, 2) shouldBe 1.5


### PR DESCRIPTION
As an example, on OSX with Scala version `2.13.1`, I see 

```
scala> def average(x: Int, xs: Int*): Double =
     | (x :: xs.to(List)).sum.toDouble / (xs.size + 1)
<console>:13: error: type mismatch;
 found   : scala.collection.immutable.List.type
 required: scala.collection.generic.CanBuildFrom[Nothing,Int,?]
       (x :: xs.to(List)).sum.toDouble / (xs.size + 1)
                   ^
```