### PR TITLE
Fix recursive type missing error

### DIFF
--- a/src/main/scala/scalatutorial/sections/ImperativeProgramming.scala
+++ b/src/main/scala/scalatutorial/sections/ImperativeProgramming.scala
@@ -31,7 +31,7 @@ object ImperativeProgramming extends ScalaTutorialSection {
    * Say you have the following two functions `iterate` and `square`:
    *
    * {{{
-   *   def iterate(n: Int, f: Int => Int, x: Int) =
+   *   def iterate(n: Int, f: Int => Int, x: Int): Int =
    *     if (n == 0) x else iterate(n-1, f, f(x))
    *   def square(x: Int) = x * x
    * }}}


### PR DESCRIPTION
Error: recursive method `iterate` needs result type