### PR TITLE
Convert int to string

### DIFF
--- a/src/main/scala/scalatutorial/sections/ImperativeProgramming.scala
+++ b/src/main/scala/scalatutorial/sections/ImperativeProgramming.scala
@@ -308,7 +308,7 @@ object ImperativeProgramming extends ScalaTutorialSection {
    * In Scala there is a kind of `for` loop:
    *
    * {{{
-   *   for (i <- 1 until 3) { System.out.print(i + " ") }
+   *   for (i <- 1 until 3) { System.out.print(i.toString + " ") }
    * }}}
    *
    * This displays `1 2`.


### PR DESCRIPTION
To avoid the deprecation warning (since 2.13.0)