### PR TITLE
Concatenate int and string (since Scala 2.13.0)

### DIFF
--- a/src/main/scala/scalatutorial/sections/ObjectOrientedProgramming.scala
+++ b/src/main/scala/scalatutorial/sections/ObjectOrientedProgramming.scala
@@ -103,7 +103,7 @@ object ObjectOrientedProgramming extends ScalaTutorialSection {
    *     )
    *
    *   def makeString(r: Rational) =
-   *     r.numer + "/" + r.denom
+   *     s"${r.numer}/${r.denom}"
    * }}}
    *
    * And then:
@@ -133,7 +133,7 @@ object ObjectOrientedProgramming extends ScalaTutorialSection {
    *       new Rational(numer * r.denom + r.numer * denom, denom * r.denom)
    *     def mul(r: Rational) = ...
    *     ...
-   *     override def toString = numer + "/" + denom
+   *     override def toString = s"$numer/$denom"
    *   }
    * }}}
    *


### PR DESCRIPTION
Method + in class Int is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`