### PR TITLE
Remove double parenthesis in tuple exercise

### DIFF
--- a/src/main/scala/scalatutorial/sections/SyntacticConveniences.scala
+++ b/src/main/scala/scalatutorial/sections/SyntacticConveniences.scala
@@ -62,7 +62,7 @@ object SyntacticConveniences extends ScalaTutorialSection {
   def tuples(res0: (Int, String)): Unit = {
     def pair(i: Int, s: String): (Int, String) = (i, s)
 
-    pair(42, "foo") shouldBe ((42, "foo"))
+    pair(42, "foo") shouldBe (42, "foo")
     pair(0, "bar") shouldBe res0
   }
 


### PR DESCRIPTION
The tuple exercise is showing tuples to be represented with double parenthesis, but single parenthesis is enough