### PR TITLE
Explain parameter promotion in ClassesVsCaseClasses

### DIFF
--- a/src/main/scala/scalatutorial/sections/ClassesVsCaseClasses.scala
+++ b/src/main/scala/scalatutorial/sections/ClassesVsCaseClasses.scala
@@ -73,7 +73,15 @@ object ClassesVsCaseClasses extends ScalaTutorialSection {
    * this is not required for case classes.
    *
    * Also, we see that the case class constructor parameters are promoted to
-   * members, whereas this is not the case with regular classes.
+   * members, whereas this is not true for regular classes: the parameters
+   * will remain private.
+   *
+   * {{{
+   *    class MyClass(x: Int) { def doubledX = x * 2 }
+   *    val myInstance = new MyClass(5)
+   *    myInstance.doubledX // returns  10
+   *    myInstance.x        // error: value x is not a member of MyClass
+   * }}}
    *
    * = Equality =
    */


### PR DESCRIPTION
Replaces usage of the phrase "not the case" w/ "not true" since the word "case" is heavily used.  Also expands on what does happen to class parameters and adds a code snippet to demonstrate (I hope I conformed here stylistically?)

Raw REPL output ala

```
scala> class MyClass(x: Int) { def doubledX = x * 2}
defined class MyClass

scala> val myInstance = new MyClass(5)
myInstance: MyClass = MyClass@129b4fe2

scala> myInstance.doubledX
res0: Int = 10

scala> myInstance.x
<console>:14: error: value x is not a member of MyClass
       myInstance.x
```

does not appear to be used anywhere