### PR TITLE
Introduce concepts of list head/tail before use

### DIFF
--- a/src/main/scala/scalatutorial/sections/StandardLibrary.scala
+++ b/src/main/scala/scalatutorial/sections/StandardLibrary.scala
@@ -61,7 +61,7 @@ object StandardLibrary extends ScalaTutorialSection {
    *
    *  - the empty list `Nil`, and
    *  - the construction operation `::` (pronounced ''cons''): `x :: xs` gives a new list
-   *    with the first element `x`, followed by the elements of `xs` (which is a list itself).
+   *    with the first element `x`, called the `head`, followed by the `tail` `xs`, which is itself a list of elements.
    *
    * For example:
    *


### PR DESCRIPTION
The concepts of the head and tail of a list are used at line 100 without first being introduced. This change introduces the concepts earlier by making a minor addition at the introductory discussion of the constructor ::.