### PR TITLE
use def instead of val

### DIFF
--- a/src/main/scala/scalatutorial/sections/StandardLibrary.scala
+++ b/src/main/scala/scalatutorial/sections/StandardLibrary.scala
@@ -136,7 +136,7 @@ object StandardLibrary extends ScalaTutorialSection {
    * Complete the definition insertion sort by filling in the blanks in the definition below:
    */
   def insertionSort(res0: (Int, Int) => Boolean, res1: List[Int]): Unit = {
-    val cond: (Int, Int) => Boolean = res0
+    def cond(a: Int, b: Int): Boolean = res0
     def insert(x: Int, xs: List[Int]): List[Int] =
       xs match {
         case List() => x :: res1


### PR DESCRIPTION
the original `val cond: (Int, Int) => Boolean = ` has to be  pretty hard for beginners (no notion about `_` before, also functions (`val`) are not so common than procedures `def`. 
Therefore I'd suggest to:
```
def cond(a: Int, b: Int): Boolean =
```
which is a standard def with named variables: `a`,`b`