### PR TITLE
result is wrong

### DIFF
--- a/src/test/scala/scalatutorial/sections/LazyEvaluationSpec.scala
+++ b/src/test/scala/scalatutorial/sections/LazyEvaluationSpec.scala
@@ -25,7 +25,7 @@ import shapeless.HNil
 class LazyEvaluationSpec extends RefSpec with Checkers {
 
   def `check lazy list range`(): Unit =
-    check(Test.testSuccess(LazyEvaluation.llRangeExercise _, 4 :: HNil))
+    check(Test.testSuccess(LazyEvaluation.llRangeExercise _, 3 :: HNil))
 
   def `check lazy val`(): Unit =
     check(Test.testSuccess(LazyEvaluation.lazyVal _, "xzyz" :: HNil))


### PR DESCRIPTION
if you run:
```
var rec = 0
def llRange(lo: Int, hi: Int): LazyList[Int] = {
  rec = rec + 1
  if (lo >= hi) LazyList.empty
  else LazyList.cons(lo, llRange(lo + 1, hi))
}
llRange(1, 10).take(3).toList

rec
```

you will get result `3` not `4`